### PR TITLE
Update opaque ptr

### DIFF
--- a/include/hip_analyzer_pass.h
+++ b/include/hip_analyzer_pass.h
@@ -220,6 +220,14 @@ class TraceType {
                             getEventCtor(mod), getIndex(bb, mod.getContext())});
     }
 
+    /** \fn getCounterType
+     * \brief Returns the scalar counter type used as a trace index. Defaults to
+     * a 32-bit integer
+     */
+    virtual llvm::Type* getCounterType(llvm::Module& mod) const {
+        return llvm::Type::getInt32Ty(mod.getContext());
+    }
+
   protected:
     static std::pair<llvm::Value*, llvm::Value*>
     getPair(llvm::LLVMContext& context, uint64_t event, uint64_t queue) {

--- a/src/llvm_instr_counters.cpp
+++ b/src/llvm_instr_counters.cpp
@@ -57,8 +57,7 @@ unsigned int StoreCounter::count(const llvm::BasicBlock& bb,
         if (const auto* store_inst = llvm::dyn_cast<llvm::StoreInst>(&instr)) {
             // store_inst->print(llvm::errs());
 
-            const auto* type =
-                store_inst->getPointerOperandType()->getContainedType(0);
+            const auto* type = store_inst->getValueOperand()->getType();
 
             if (isTypeCounted(type, type_filter)) {
                 counted += type->getPrimitiveSizeInBits() / bits_per_byte;
@@ -76,8 +75,7 @@ unsigned int LoadCounter::count(const llvm::BasicBlock& bb,
         if (const auto* load_inst = llvm::dyn_cast<llvm::LoadInst>(&instr)) {
             // load_inst->print(llvm::errs());
 
-            const auto* type =
-                load_inst->getPointerOperandType()->getContainedType(0);
+            const auto* type = load_inst->getType();
 
             if (isTypeCounted(type, type_filter)) {
                 counted += type->getPrimitiveSizeInBits() / bits_per_byte;

--- a/src/pass/ir_codegen.cpp
+++ b/src/pass/ir_codegen.cpp
@@ -309,20 +309,18 @@ TracingFunctions::TracingFunctions(llvm::Module& mod) {
     auto& context = mod.getContext();
 
     auto* void_type = llvm::Type::getVoidTy(context);
-    auto* uint8_type = llvm::Type::getInt8Ty(context);
-    auto* uint8_ptr_type = uint8_type->getPointerTo();
+    auto* ptr_type = llvm::PointerType::getUnqual(context);
     auto* uint64_type = llvm::Type::getInt64Ty(context);
     auto* uint32_type = llvm::Type::getInt32Ty(context);
 
     auto* _hip_event_ctor_type = getEventCtorType(context);
 
     auto* offset_getter_type = llvm::FunctionType::get(
-        uint8_ptr_type,
-        {uint8_ptr_type, uint64_type->getPointerTo(), uint64_type}, false);
+        ptr_type, {ptr_type, uint64_type->getPointerTo(), uint64_type}, false);
 
     auto* event_creator_type = llvm::FunctionType::get(
         void_type,
-        {uint8_ptr_type, uint32_type->getPointerTo(), uint64_type,
+        {ptr_type, uint32_type->getPointerTo(), uint64_type,
          _hip_event_ctor_type->getPointerTo(), uint64_type},
         false);
 

--- a/src/pass/ir_codegen.cpp
+++ b/src/pass/ir_codegen.cpp
@@ -222,9 +222,7 @@ InstrumentationFunctions::InstrumentationFunctions(llvm::Module& mod) {
 
     auto* void_type = llvm::Type::getVoidTy(context);
     auto* uint32_type = llvm::Type::getInt32Ty(context);
-    auto* unqual_ptr_type = llvm::Type::getInt8PtrTy(context);
-    // FIXME kind of a hack so far, but HIP has not
-    // updated to opaque pointers so far
+    auto* unqual_ptr_type = llvm::PointerType::getUnqual(context);
 
     auto void_from_ptr_type =
         llvm::FunctionType::get(void_type, {unqual_ptr_type}, false);
@@ -288,21 +286,20 @@ CfgFunctions::CfgFunctions(llvm::Module& mod) {
     auto& context = mod.getContext();
 
     auto* void_type = llvm::Type::getVoidTy(context);
-    auto* uint8_ptr_type = llvm::Type::getInt8PtrTy(context);
+    auto* ptr_type = llvm::PointerType::getUnqual(context);
     auto* uint64_type = llvm::Type::getInt64Ty(context);
 
     auto* _hip_store_ctr_type = llvm::FunctionType::get(
-        void_type, {uint8_ptr_type, uint64_type, uint8_ptr_type}, false);
+        void_type, {ptr_type, uint64_type, ptr_type}, false);
 
     _hip_store_ctr = getFunction(mod, "_hip_store_ctr", _hip_store_ctr_type);
 }
 
 llvm::FunctionType* getEventCtorType(llvm::LLVMContext& context) {
     auto* void_type = llvm::Type::getVoidTy(context);
-    auto* uint8_ptr_type = llvm::Type::getInt8PtrTy(context);
+    auto* ptr_type = llvm::PointerType::getUnqual(context);
     auto* uint64_type = llvm::Type::getInt64Ty(context);
-    return llvm::FunctionType::get(void_type, {uint8_ptr_type, uint64_type},
-                                   false);
+    return llvm::FunctionType::get(void_type, {ptr_type, uint64_type}, false);
 }
 
 TracingFunctions::TracingFunctions(llvm::Module& mod) {
@@ -311,17 +308,16 @@ TracingFunctions::TracingFunctions(llvm::Module& mod) {
     auto* void_type = llvm::Type::getVoidTy(context);
     auto* ptr_type = llvm::PointerType::getUnqual(context);
     auto* uint64_type = llvm::Type::getInt64Ty(context);
-    auto* uint32_type = llvm::Type::getInt32Ty(context);
+    // auto* uint32_type = llvm::Type::getInt32Ty(context);
 
-    auto* _hip_event_ctor_type = getEventCtorType(context);
+    // Unqual ptr hides function pointers?
+    // auto* _hip_event_ctor_type = getEventCtorType(context);
 
     auto* offset_getter_type = llvm::FunctionType::get(
-        ptr_type, {ptr_type, uint64_type->getPointerTo(), uint64_type}, false);
+        ptr_type, {ptr_type, ptr_type, uint64_type}, false);
 
     auto* event_creator_type = llvm::FunctionType::get(
-        void_type,
-        {ptr_type, uint32_type->getPointerTo(), uint64_type,
-         _hip_event_ctor_type->getPointerTo(), uint64_type},
+        void_type, {ptr_type, ptr_type, uint64_type, ptr_type, uint64_type},
         false);
 
     _hip_get_trace_offset =

--- a/test/wavestate.cpp
+++ b/test/wavestate.cpp
@@ -8,7 +8,7 @@
 
 // It's bad, I know, but no LTO for the device otherwise and time is getting
 // tight
-#include "../src/pass/gpu_pass_instr.cpp"
+#include "../src/pass/gpu_pass_instr.hip"
 
 #include <iostream>
 


### PR DESCRIPTION
Update to ROCm 5.5.0 w/ LLVM 16 (Opaque pointers)