### PR TITLE
Instrumentation library tracepoints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(hip-analyzer LANGUAGES C CXX)
 
 
 set(CMAKE_CXX_STANDARD 20)
-list(APPEND CMAKE_CXX_FLAGS "-Wall -O3 -fPIE -fno-rtti")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3 -fPIE -fno-rtti")
 
 option(ENABLE_TRACEPOINTS "Enable LTTng-UST Tracepoints" OFF)
 
@@ -53,6 +53,7 @@ include_directories(/usr/include/jsoncpp) # quick hack but I'm tired of fighting
 if(ENABLE_TRACEPOINTS)
     find_package(LTTngUST REQUIRED)
     add_definitions(-DENABLE_TRACEPOINTS)
+    set(ENABLE_TRACEPOINTS_FLAGS -DENABLE_TRACEPOINTS)
 endif()
 
 # ----- Targets definitions ----- #
@@ -72,7 +73,7 @@ add_custom_command(
 
 add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/queue_info.o
-    COMMAND ${ROCM_PATH}/hip/bin/hipcc -fPIE -c -I${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src/queue_info.cpp -std=c++20 -o ${CMAKE_BINARY_DIR}/queue_info.o
+    COMMAND ${ROCM_PATH}/hip/bin/hipcc -fPIE -c -I${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src/queue_info.cpp -std=c++20 -o ${CMAKE_BINARY_DIR}/queue_info.o ${ENABLE_TRACEPOINTS_FLAGS}
     DEPENDS 
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_instrumentation.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/queue_info.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ add_library(hip_instrumentation
     src/gpu_info.cpp
     src/state_recoverer.cpp
     src/hip_instrumentation_cbindings.cpp
+    src/hip_instrumentation_tracepoint_provider.cpp
     ${CMAKE_BINARY_DIR}/gpu_hip_instrumentation.o
     ${CMAKE_BINARY_DIR}/queue_info.o
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(hip-analyzer LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 20)
 list(APPEND CMAKE_CXX_FLAGS "-Wall -O3 -fPIE -fno-rtti")
 
+option(ENABLE_TRACEPOINTS "Enable LTTng-UST Tracepoints" OFF)
+
 # ---- Paths setup ----- #
 
 string(REPLACE ":" ";" CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
@@ -47,6 +49,11 @@ include_directories(
 # jsoncpp
 
 include_directories(/usr/include/jsoncpp) # quick hack but I'm tired of fighting CMake
+
+if(ENABLE_TRACEPOINTS)
+    find_package(LTTngUST REQUIRED)
+    add_definitions(-DENABLE_TRACEPOINTS)
+endif()
 
 # ----- Targets definitions ----- #
 
@@ -145,6 +152,10 @@ target_link_libraries(hip_instrumentation
     dl
     pthread
 )
+
+if(ENABLE_TRACEPOINTS)
+    target_link_libraries(hip_instrumentation LTTng::UST)
+endif()
 
 
 # ----- Testing ----- #

--- a/include/hip_analyzer_tracepoints.h
+++ b/include/hip_analyzer_tracepoints.h
@@ -8,17 +8,139 @@
 #undef LTTNG_UST_TRACEPOINT_INCLUDE
 #define LTTNG_UST_TRACEPOINT_INCLUDE "hip_analyzer_tracepoints.h"
 
-#if !defined(_TP_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
-#define _TP_H
+#if !defined(_HIP_INSTRUMENTATION_TP_H) ||                                     \
+    defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define _HIP_INSTRUMENTATION_TP_H
 
 #include <lttng/tracepoint.h>
 
-/*
- * Use LTTNG_UST_TRACEPOINT_EVENT(), LTTNG_UST_TRACEPOINT_EVENT_CLASS(),
- * LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(), and
- * LTTNG_UST_TRACEPOINT_LOGLEVEL() here.
- */
+// ----- Memory operations ----- //
 
-#endif /* _TP_H */
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(
+    hip_instrumentation, memory, LTTNG_UST_TP_ARGS(void*, device_ptr),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(size_t, device_ptr,
+                                                    device_ptr)))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, memory,
+                                    hip_instrumentation, hipMalloc,
+                                    LTTNG_UST_TP_ARGS(void*, device_ptr))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, memory,
+                                    hip_instrumentation, hipFree,
+                                    LTTNG_UST_TP_ARGS(void*, device_ptr))
+
+// ----- HIP Instrumentation handlers ----- //
+
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(
+    hip_instrumentation, instr_activity, LTTNG_UST_TP_ARGS(void*, instr),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(size_t, inst, instr)))
+
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(
+    hip_instrumentation, instr_activity_ptr,
+    LTTNG_UST_TP_ARGS(void*, instr, void* ptr),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(size_t, instr, instr),
+                        lttng_ust_field_integer_hex(size_t, instr, instr)))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, new_instrumenter,
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, delete_instrumenter,
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, instr_to_device_begin,
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
+                                    hip_instrumentation, instr_to_device_end,
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter,
+                                                      void*, ptr))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation,
+                                    instr_from_device_begin,
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
+                                    hip_instrumentation, instr_from_device_end,
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter,
+                                                      void*, ptr))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, queue_compute_begin,
+                                    LTTNG_UST_TP_ARGS(void*, queue_info))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, queue_compute_end,
+                                    LTTNG_UST_TP_ARGS(void*, queue_info))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, queue_record,
+                                    LTTNG_UST_TP_ARGS(void*, queue_info))
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    hip_instrumentation, state_recoverer_register,
+    LTTNG_UST_TP_ARGS(void*, state_recoverer, void*, device_ptr, void*,
+                      copy_ptr),
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer_hex(size_t, state_recoverer, state_recoverer),
+        lttng_ust_field_integer_hex(size_t, device_ptr, device_ptr)))
+
+LTTNG_UST_TRACEPOINT_EVENT(hip_instrumentation, state_recoverer_cleanup,
+                           LTTNG_UST_TP_ARGS(void*, state_recoverer),
+                           LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(
+                               size_t, state_recoverer, state_recoverer)))
+
+// ----- Trace management ----- //
+
+// Main thread
+
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(
+    hip_instrumentation, trace_record,
+    LTTNG_UST_TP_ARGS(void*, instr, void*, data, uint64_t, instr_stamp),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(size_t, instr, instr),
+                        lttng_ust_field_integer_hex(size_t, data, data),
+                        lttng_ust_field_integer(uint64_t, instr_stamp,
+                                                instr_stamp)))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    hip_instrumentation, trace_record, hip_instrumentation,
+    register_thread_counters, LTTNG_UST_TP_ARGS(void*, instr, void*, data))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, trace_record,
+                                    hip_instrumentation, register_wave_counters,
+                                    LTTNG_UST_TP_ARGS(void*, instr, void*, data,
+                                                      uint64_t, stamp))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, trace_record,
+                                    hip_instrumentation, register_queue,
+                                    LTTNG_UST_TP_ARGS(void*, instr, void*, data,
+                                                      uint64_t, stamp))
+
+// Collector thread
+
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(
+    hip_instrumentation, collector_dump,
+    LTTNG_UST_TP_ARGS(void*, ostream, void*, data, uint64_t, instr_stamp),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(size_t, ostream, ostream),
+                        lttng_ust_field_integer_hex(size_t, data, data),
+                        lttng_ust_field_integer(uint64_t, instr_stamp,
+                                                instr_stamp)))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    hip_instrumentation, collector, hip_instrumentation, collector_dump_thread,
+    LTTNG_UST_TP_ARGS(void*, ostream, void*, data, uint64_t, instr_stamp))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    hip_instrumentation, collector, hip_instrumentation, collector_dump_wave,
+    LTTNG_UST_TP_ARGS(void*, ostream, void*, data, uint64_t, instr_stamp))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    hip_instrumentation, collector, hip_instrumentation, collector_dump_queue,
+    LTTNG_UST_TP_ARGS(void*, ostream, void*, data, uint64_t, instr_stamp))
+
+#endif /*_HIP_INSTRUMENTATION_TP_H */
 
 #include <lttng/tracepoint-event.h>

--- a/include/hip_analyzer_tracepoints.h
+++ b/include/hip_analyzer_tracepoints.h
@@ -2,8 +2,10 @@
  * \brief LTTng-ust tracepoints for hip analyzer runtime
  */
 
+#ifdef ENABLE_TRACEPOINTS
+
 #undef LTTNG_UST_TRACEPOINT_PROVIDER
-#define LTTNG_UST_TRACEPOINT_PROVIDER hip_analyzer
+#define LTTNG_UST_TRACEPOINT_PROVIDER hip_instrumentation
 
 #undef LTTNG_UST_TRACEPOINT_INCLUDE
 #define LTTNG_UST_TRACEPOINT_INCLUDE "hip_analyzer_tracepoints.h"
@@ -17,29 +19,33 @@
 // ----- Memory operations ----- //
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
-    hip_instrumentation, memory, LTTNG_UST_TP_ARGS(void*, device_ptr),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(size_t, device_ptr,
-                                                    device_ptr)))
+    hip_instrumentation, memory, LTTNG_UST_TP_ARGS(const void*, device_ptr),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(
+        uintptr_t, device_ptr, reinterpret_cast<uintptr_t>(device_ptr))))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, memory,
                                     hip_instrumentation, hipMalloc,
-                                    LTTNG_UST_TP_ARGS(void*, device_ptr))
+                                    LTTNG_UST_TP_ARGS(const void*, device_ptr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, memory,
                                     hip_instrumentation, hipFree,
-                                    LTTNG_UST_TP_ARGS(void*, device_ptr))
+                                    LTTNG_UST_TP_ARGS(const void*, device_ptr))
 
 // ----- HIP Instrumentation handlers ----- //
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
     hip_instrumentation, instr_activity, LTTNG_UST_TP_ARGS(void*, instr),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(size_t, inst, instr)))
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(
+        uintptr_t, inst, reinterpret_cast<uintptr_t>(instr))))
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
     hip_instrumentation, instr_activity_ptr,
-    LTTNG_UST_TP_ARGS(void*, instr, void* ptr),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(size_t, instr, instr),
-                        lttng_ust_field_integer_hex(size_t, instr, instr)))
+    LTTNG_UST_TP_ARGS(void*, instr, const void*, ptr),
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer_hex(uintptr_t, instr,
+                                    reinterpret_cast<uintptr_t>(instr))
+            lttng_ust_field_integer_hex(uintptr_t, ptr,
+                                        reinterpret_cast<uintptr_t>(ptr))))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, new_instrumenter,
@@ -56,42 +62,72 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation, instr_to_device_end,
                                     LTTNG_UST_TP_ARGS(void*, instrumenter,
-                                                      void*, ptr))
+                                                      const void*, ptr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, instr_sync_begin,
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, instr_sync_end,
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, instr_record_begin,
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, instr_record_end,
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation,
                                     instr_from_device_begin,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+                                    LTTNG_UST_TP_ARGS(void*, instrumenter,
+                                                      const void*, ptr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation, instr_from_device_end,
                                     LTTNG_UST_TP_ARGS(void*, instrumenter,
-                                                      void*, ptr))
+                                                      const void*, ptr))
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+// Queue info
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation, queue_compute_begin,
-                                    LTTNG_UST_TP_ARGS(void*, queue_info))
+                                    LTTNG_UST_TP_ARGS(void*, queue_info, void*,
+                                                      instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, queue_compute_end,
                                     LTTNG_UST_TP_ARGS(void*, queue_info))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
-                                    hip_instrumentation, queue_record,
+                                    hip_instrumentation, queue_record_begin,
                                     LTTNG_UST_TP_ARGS(void*, queue_info))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, queue_record_end,
+                                    LTTNG_UST_TP_ARGS(void*, queue_info))
+
+// State recoverer
 
 LTTNG_UST_TRACEPOINT_EVENT(
     hip_instrumentation, state_recoverer_register,
-    LTTNG_UST_TP_ARGS(void*, state_recoverer, void*, device_ptr, void*,
-                      copy_ptr),
-    LTTNG_UST_TP_FIELDS(
-        lttng_ust_field_integer_hex(size_t, state_recoverer, state_recoverer),
-        lttng_ust_field_integer_hex(size_t, device_ptr, device_ptr)))
+    LTTNG_UST_TP_ARGS(void*, state_recoverer, const void*, device_ptr,
+                      const void*, copy_ptr),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(
+        uintptr_t, state_recoverer,
+        reinterpret_cast<uintptr_t>(state_recoverer))
+                            lttng_ust_field_integer_hex(
+                                uintptr_t, device_ptr,
+                                reinterpret_cast<uintptr_t>(device_ptr))))
 
 LTTNG_UST_TRACEPOINT_EVENT(hip_instrumentation, state_recoverer_cleanup,
                            LTTNG_UST_TP_ARGS(void*, state_recoverer),
                            LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(
-                               size_t, state_recoverer, state_recoverer)))
+                               uintptr_t, state_recoverer,
+                               reinterpret_cast<uintptr_t>(state_recoverer))))
 
 // ----- Trace management ----- //
 
@@ -100,47 +136,71 @@ LTTNG_UST_TRACEPOINT_EVENT(hip_instrumentation, state_recoverer_cleanup,
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
     hip_instrumentation, trace_record,
     LTTNG_UST_TP_ARGS(void*, instr, void*, data, uint64_t, instr_stamp),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(size_t, instr, instr),
-                        lttng_ust_field_integer_hex(size_t, data, data),
-                        lttng_ust_field_integer(uint64_t, instr_stamp,
-                                                instr_stamp)))
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer_hex(uintptr_t, instr,
+                                    reinterpret_cast<uintptr_t>(instr))
+            lttng_ust_field_integer_hex(uintptr_t, data,
+                                        reinterpret_cast<uintptr_t>(data))
+                lttng_ust_field_integer(uint64_t, instr_stamp, instr_stamp)))
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    hip_instrumentation, trace_record, hip_instrumentation,
-    register_thread_counters, LTTNG_UST_TP_ARGS(void*, instr, void*, data))
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, trace_record,
+                                    hip_instrumentation,
+                                    register_thread_counters,
+                                    LTTNG_UST_TP_ARGS(void*, instr, const void*,
+                                                      data))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, trace_record,
                                     hip_instrumentation, register_wave_counters,
-                                    LTTNG_UST_TP_ARGS(void*, instr, void*, data,
-                                                      uint64_t, stamp))
+                                    LTTNG_UST_TP_ARGS(void*, instr, const void*,
+                                                      data, uint64_t, stamp))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, trace_record,
                                     hip_instrumentation, register_queue,
-                                    LTTNG_UST_TP_ARGS(void*, instr, void*, data,
-                                                      uint64_t, stamp))
+                                    LTTNG_UST_TP_ARGS(void*, instr, const void*,
+                                                      data, uint64_t, stamp))
 
 // Collector thread
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
     hip_instrumentation, collector_dump,
-    LTTNG_UST_TP_ARGS(void*, ostream, void*, data, uint64_t, instr_stamp),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(size_t, ostream, ostream),
-                        lttng_ust_field_integer_hex(size_t, data, data),
-                        lttng_ust_field_integer(uint64_t, instr_stamp,
-                                                instr_stamp)))
+    LTTNG_UST_TP_ARGS(void*, ostream, const void*, data, uint64_t, instr_stamp),
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer_hex(uintptr_t, ostream,
+                                    reinterpret_cast<uintptr_t>(ostream))
+            lttng_ust_field_integer_hex(uintptr_t, data,
+                                        reinterpret_cast<uintptr_t>(data))
+                lttng_ust_field_integer(uint64_t, instr_stamp, instr_stamp)))
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    hip_instrumentation, collector, hip_instrumentation, collector_dump_thread,
-    LTTNG_UST_TP_ARGS(void*, ostream, void*, data, uint64_t, instr_stamp))
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, collector_dump,
+                                    hip_instrumentation, collector_dump_thread,
+                                    LTTNG_UST_TP_ARGS(void*, ostream,
+                                                      const void*, data,
+                                                      uint64_t, instr_stamp))
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    hip_instrumentation, collector, hip_instrumentation, collector_dump_wave,
-    LTTNG_UST_TP_ARGS(void*, ostream, void*, data, uint64_t, instr_stamp))
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, collector_dump,
+                                    hip_instrumentation, collector_dump_wave,
+                                    LTTNG_UST_TP_ARGS(void*, ostream,
+                                                      const void*, data,
+                                                      uint64_t, instr_stamp))
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    hip_instrumentation, collector, hip_instrumentation, collector_dump_queue,
-    LTTNG_UST_TP_ARGS(void*, ostream, void*, data, uint64_t, instr_stamp))
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, collector_dump,
+                                    hip_instrumentation, collector_dump_queue,
+                                    LTTNG_UST_TP_ARGS(void*, ostream,
+                                                      const void*, data,
+                                                      uint64_t, instr_stamp))
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    hip_instrumentation, collector_dump_end,
+    LTTNG_UST_TP_ARGS(const void*, data, uint64_t, instr_stamp),
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer_hex(uintptr_t, data,
+                                    reinterpret_cast<uintptr_t>(data))
+            lttng_ust_field_integer(uint64_t, instr_stamp, instr_stamp)))
 
 #endif /*_HIP_INSTRUMENTATION_TP_H */
 
 #include <lttng/tracepoint-event.h>
+
+#else
+#define lttng_ust_tracepoint(...)
+#endif

--- a/include/hip_analyzer_tracepoints.h
+++ b/include/hip_analyzer_tracepoints.h
@@ -49,73 +49,66 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, new_instrumenter,
-                                    LTTNG_UST_TP_ARGS(const void*,
-                                                      instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, delete_instrumenter,
-                                    LTTNG_UST_TP_ARGS(const void*,
-                                                      instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, instr_to_device_begin,
-                                    LTTNG_UST_TP_ARGS(const void*,
-                                                      instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation, instr_to_device_end,
-                                    LTTNG_UST_TP_ARGS(const void*, instrumenter,
+                                    LTTNG_UST_TP_ARGS(const void*, instr,
                                                       const void*, ptr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, instr_sync_begin,
-                                    LTTNG_UST_TP_ARGS(const void*,
-                                                      instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, instr_sync_end,
-                                    LTTNG_UST_TP_ARGS(const void*,
-                                                      instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, instr_record_begin,
-                                    LTTNG_UST_TP_ARGS(const void*,
-                                                      instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, instr_record_end,
-                                    LTTNG_UST_TP_ARGS(const void*,
-                                                      instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation,
                                     instr_from_device_begin,
-                                    LTTNG_UST_TP_ARGS(const void*, instrumenter,
+                                    LTTNG_UST_TP_ARGS(const void*, instr,
                                                       const void*, ptr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation, instr_from_device_end,
-                                    LTTNG_UST_TP_ARGS(const void*, instrumenter,
+                                    LTTNG_UST_TP_ARGS(const void*, instr,
                                                       const void*, ptr))
 
 // Queue info
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation, queue_compute_begin,
-                                    LTTNG_UST_TP_ARGS(const void*, queue_info,
-                                                      const void*, instr))
+                                    LTTNG_UST_TP_ARGS(const void*, instr,
+                                                      const void*, ptr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, queue_compute_end,
-                                    LTTNG_UST_TP_ARGS(const void*, queue_info))
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, queue_record_begin,
-                                    LTTNG_UST_TP_ARGS(const void*, queue_info))
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, queue_record_end,
-                                    LTTNG_UST_TP_ARGS(const void*, queue_info))
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
 
 // State recoverer
 
@@ -151,11 +144,10 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
                                         reinterpret_cast<uintptr_t>(data))
                 lttng_ust_field_integer(uint64_t, instr_stamp, instr_stamp)))
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, trace_record,
-                                    hip_instrumentation,
-                                    register_thread_counters,
-                                    LTTNG_UST_TP_ARGS(const void*, instr,
-                                                      const void*, data))
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    hip_instrumentation, trace_record, hip_instrumentation,
+    register_thread_counters,
+    LTTNG_UST_TP_ARGS(const void*, instr, const void*, data, uint64_t, stamp))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, trace_record,
                                     hip_instrumentation, register_wave_counters,

--- a/include/hip_analyzer_tracepoints.h
+++ b/include/hip_analyzer_tracepoints.h
@@ -47,9 +47,12 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
             lttng_ust_field_integer_hex(uintptr_t, ptr,
                                         reinterpret_cast<uintptr_t>(ptr))))
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
-                                    hip_instrumentation, new_instrumenter,
-                                    LTTNG_UST_TP_ARGS(const void*, instr))
+LTTNG_UST_TRACEPOINT_EVENT(
+    hip_instrumentation, new_instrumenter,
+    LTTNG_UST_TP_ARGS(const void*, instr, const char*, kernel),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(
+        uintptr_t, instr, reinterpret_cast<uintptr_t>(instr))
+                            lttng_ust_field_string(kernel, kernel)))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, delete_instrumenter,

--- a/include/hip_analyzer_tracepoints.h
+++ b/include/hip_analyzer_tracepoints.h
@@ -204,6 +204,16 @@ LTTNG_UST_TRACEPOINT_EVENT(
                                     reinterpret_cast<uintptr_t>(data))
             lttng_ust_field_integer(uint64_t, instr_stamp, instr_stamp)))
 
+// ----- Kernel timing pass ----- //
+
+LTTNG_UST_TRACEPOINT_EVENT(hip_instrumentation, kernel_timer_begin,
+                           LTTNG_UST_TP_ARGS(const char*, kernel),
+                           LTTNG_UST_TP_FIELDS(lttng_ust_field_string(kernel,
+                                                                      kernel)))
+
+LTTNG_UST_TRACEPOINT_EVENT(hip_instrumentation, kernel_timer_end,
+                           LTTNG_UST_TP_ARGS(), LTTNG_UST_TP_FIELDS())
+
 #endif /*_HIP_INSTRUMENTATION_TP_H */
 
 #include <lttng/tracepoint-event.h>

--- a/include/hip_analyzer_tracepoints.h
+++ b/include/hip_analyzer_tracepoints.h
@@ -135,7 +135,7 @@ LTTNG_UST_TRACEPOINT_EVENT(hip_instrumentation, state_recoverer_cleanup,
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
     hip_instrumentation, trace_record,
-    LTTNG_UST_TP_ARGS(void*, instr, void*, data, uint64_t, instr_stamp),
+    LTTNG_UST_TP_ARGS(const void*, instr, void*, data, uint64_t, instr_stamp),
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer_hex(uintptr_t, instr,
                                     reinterpret_cast<uintptr_t>(instr))
@@ -146,18 +146,18 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, trace_record,
                                     hip_instrumentation,
                                     register_thread_counters,
-                                    LTTNG_UST_TP_ARGS(void*, instr, const void*,
-                                                      data))
+                                    LTTNG_UST_TP_ARGS(const void*, instr,
+                                                      const void*, data))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, trace_record,
                                     hip_instrumentation, register_wave_counters,
-                                    LTTNG_UST_TP_ARGS(void*, instr, const void*,
-                                                      data, uint64_t, stamp))
+                                    LTTNG_UST_TP_ARGS(const void*, instr,
+                                                      const void*, data,
+                                                      uint64_t, stamp))
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, trace_record,
-                                    hip_instrumentation, register_queue,
-                                    LTTNG_UST_TP_ARGS(void*, instr, const void*,
-                                                      data, uint64_t, stamp))
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    hip_instrumentation, trace_record, hip_instrumentation, register_queue,
+    LTTNG_UST_TP_ARGS(const void*, instr, const void*, data, uint64_t, stamp))
 
 // Collector thread
 

--- a/include/hip_analyzer_tracepoints.h
+++ b/include/hip_analyzer_tracepoints.h
@@ -115,6 +115,10 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
 
 // State recoverer
 
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
+                                    hip_instrumentation, new_state_recoverer,
+                                    LTTNG_UST_TP_ARGS(const void*, instr))
+
 LTTNG_UST_TRACEPOINT_EVENT(
     hip_instrumentation, state_recoverer_register,
     LTTNG_UST_TP_ARGS(const void*, state_recoverer, const void*, device_ptr,

--- a/include/hip_analyzer_tracepoints.h
+++ b/include/hip_analyzer_tracepoints.h
@@ -34,13 +34,13 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, memory,
 // ----- HIP Instrumentation handlers ----- //
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
-    hip_instrumentation, instr_activity, LTTNG_UST_TP_ARGS(void*, instr),
+    hip_instrumentation, instr_activity, LTTNG_UST_TP_ARGS(const void*, instr),
     LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(
         uintptr_t, inst, reinterpret_cast<uintptr_t>(instr))))
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
     hip_instrumentation, instr_activity_ptr,
-    LTTNG_UST_TP_ARGS(void*, instr, const void*, ptr),
+    LTTNG_UST_TP_ARGS(const void*, instr, const void*, ptr),
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer_hex(uintptr_t, instr,
                                     reinterpret_cast<uintptr_t>(instr))
@@ -49,72 +49,79 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, new_instrumenter,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*,
+                                                      instrumenter))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, delete_instrumenter,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*,
+                                                      instrumenter))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, instr_to_device_begin,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*,
+                                                      instrumenter))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation, instr_to_device_end,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter,
+                                    LTTNG_UST_TP_ARGS(const void*, instrumenter,
                                                       const void*, ptr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, instr_sync_begin,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*,
+                                                      instrumenter))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, instr_sync_end,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*,
+                                                      instrumenter))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, instr_record_begin,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*,
+                                                      instrumenter))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, instr_record_end,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter))
+                                    LTTNG_UST_TP_ARGS(const void*,
+                                                      instrumenter))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation,
                                     instr_from_device_begin,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter,
+                                    LTTNG_UST_TP_ARGS(const void*, instrumenter,
                                                       const void*, ptr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation, instr_from_device_end,
-                                    LTTNG_UST_TP_ARGS(void*, instrumenter,
+                                    LTTNG_UST_TP_ARGS(const void*, instrumenter,
                                                       const void*, ptr))
 
 // Queue info
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity_ptr,
                                     hip_instrumentation, queue_compute_begin,
-                                    LTTNG_UST_TP_ARGS(void*, queue_info, void*,
-                                                      instr))
+                                    LTTNG_UST_TP_ARGS(const void*, queue_info,
+                                                      const void*, instr))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, queue_compute_end,
-                                    LTTNG_UST_TP_ARGS(void*, queue_info))
+                                    LTTNG_UST_TP_ARGS(const void*, queue_info))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, queue_record_begin,
-                                    LTTNG_UST_TP_ARGS(void*, queue_info))
+                                    LTTNG_UST_TP_ARGS(const void*, queue_info))
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(hip_instrumentation, instr_activity,
                                     hip_instrumentation, queue_record_end,
-                                    LTTNG_UST_TP_ARGS(void*, queue_info))
+                                    LTTNG_UST_TP_ARGS(const void*, queue_info))
 
 // State recoverer
 
 LTTNG_UST_TRACEPOINT_EVENT(
     hip_instrumentation, state_recoverer_register,
-    LTTNG_UST_TP_ARGS(void*, state_recoverer, const void*, device_ptr,
+    LTTNG_UST_TP_ARGS(const void*, state_recoverer, const void*, device_ptr,
                       const void*, copy_ptr),
     LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(
         uintptr_t, state_recoverer,
@@ -124,7 +131,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
                                 reinterpret_cast<uintptr_t>(device_ptr))))
 
 LTTNG_UST_TRACEPOINT_EVENT(hip_instrumentation, state_recoverer_cleanup,
-                           LTTNG_UST_TP_ARGS(void*, state_recoverer),
+                           LTTNG_UST_TP_ARGS(const void*, state_recoverer),
                            LTTNG_UST_TP_FIELDS(lttng_ust_field_integer_hex(
                                uintptr_t, state_recoverer,
                                reinterpret_cast<uintptr_t>(state_recoverer))))
@@ -135,7 +142,8 @@ LTTNG_UST_TRACEPOINT_EVENT(hip_instrumentation, state_recoverer_cleanup,
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
     hip_instrumentation, trace_record,
-    LTTNG_UST_TP_ARGS(const void*, instr, void*, data, uint64_t, instr_stamp),
+    LTTNG_UST_TP_ARGS(const void*, instr, const void*, data, uint64_t,
+                      instr_stamp),
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer_hex(uintptr_t, instr,
                                     reinterpret_cast<uintptr_t>(instr))

--- a/include/hip_instrumentation/queue_info.hpp
+++ b/include/hip_instrumentation/queue_info.hpp
@@ -145,6 +145,12 @@ struct QueueInfo {
      */
     void record(void* ptr);
 
+    const CounterInstrumenter* getInstrumenter() const {
+        return std::visit(
+            [](const auto& i) { return static_cast<CounterInstrumenter*>(i); },
+            instr);
+    }
+
   private:
     QueueInfo(ThreadCounterInstrumenter& instr, size_t elem_size,
               bool is_thread, const std::string& type_desc,

--- a/src/hip_instrumentation_cbindings.cpp
+++ b/src/hip_instrumentation_cbindings.cpp
@@ -112,7 +112,7 @@ void freeHipInstrumenter(hip::CounterInstrumenter* instr) {
 
 hip::StateRecoverer* hipNewStateRecoverer() {
     auto* s = new hip::StateRecoverer;
-
+    lttng_ust_tracepoint(hip_instrumentation, new_state_recoverer, s);
     return s;
 }
 

--- a/src/hip_instrumentation_cbindings.cpp
+++ b/src/hip_instrumentation_cbindings.cpp
@@ -249,23 +249,8 @@ void freeHipQueueInfo(hip::QueueInfo* q) { delete q; }
 
 // ----- Experimental - Kernel timer ----- //
 
-std::ofstream kernel_timer_output;
-
-auto kernel_timer = std::chrono::steady_clock::now();
-
 void begin_kernel_timer(const char* kernel) {
-    if (!kernel_timer_output.is_open()) {
-        std::string prefix = "original";
-        if (auto* benchmark = std::getenv("RODINIA_BENCHMARK")) {
-            prefix += benchmark;
-            prefix += '_';
-        }
-
-        kernel_timer_output.open(prefix + "timing.csv", std::ofstream::trunc);
-        kernel_timer_output << "kernel,original\n";
-    }
-    kernel_timer_output << kernel << ',';
-    kernel_timer = std::chrono::steady_clock::now();
+    lttng_ust_tracepoint(hip_instrumentation, kernel_timer_begin, kernel);
 }
 
 void end_kernel_timer() {
@@ -273,11 +258,6 @@ void end_kernel_timer() {
         return;
     }
 
-    auto t1 = std::chrono::steady_clock::now();
-    kernel_timer_output << std::chrono::duration_cast<std::chrono::nanoseconds>(
-                               t1 - kernel_timer)
-                               .count()
-                        << '\n';
-    kernel_timer_output.flush();
+    lttng_ust_tracepoint(hip_instrumentation, kernel_timer_end);
 }
 }

--- a/src/hip_instrumentation_cbindings.cpp
+++ b/src/hip_instrumentation_cbindings.cpp
@@ -17,6 +17,13 @@
 #include <fstream>
 #include <stdexcept>
 
+#ifdef ENABLE_TRACEPOINTS
+#define LTTNG_UST_TRACEPOINT_DEFINE
+#include "hip_analyzer_tracepoints.h"
+#else
+#define lttng_ust_tracepoint(...)
+#endif
+
 std::ofstream timer;
 
 auto last_t = std::chrono::steady_clock::now();

--- a/src/hip_instrumentation_cbindings.cpp
+++ b/src/hip_instrumentation_cbindings.cpp
@@ -66,7 +66,8 @@ hip::CounterInstrumenter* hipNewInstrumenter(const char* kernel_name,
         break;
     }
 
-    lttng_ust_tracepoint(hip_instrumentation, new_instrumenter, instr);
+    lttng_ust_tracepoint(hip_instrumentation, new_instrumenter, instr,
+                         kernel_name);
 
     unsigned int bblocks = instr->loadDatabase(kernel_name).size();
 

--- a/src/hip_instrumentation_cbindings.cpp
+++ b/src/hip_instrumentation_cbindings.cpp
@@ -17,7 +17,6 @@
 #include <fstream>
 #include <stdexcept>
 
-#define LTTNG_UST_TRACEPOINT_DEFINE
 #include "hip_analyzer_tracepoints.h"
 
 std::ofstream timer;

--- a/src/hip_instrumentation_tracepoint_provider.cpp
+++ b/src/hip_instrumentation_tracepoint_provider.cpp
@@ -7,7 +7,7 @@
 #ifdef ENABLE_TRACEPOINTS
 
 #define LTTNG_UST_TRACEPOINT_CREATE_PROBES
-#define LTTNG_UST_TRACEPOINT_DEINE
+#define LTTNG_UST_TRACEPOINT_DEFINE
 
 #include "hip_analyzer_tracepoints.h"
 

--- a/src/hip_instrumentation_tracepoint_provider.cpp
+++ b/src/hip_instrumentation_tracepoint_provider.cpp
@@ -1,0 +1,14 @@
+/** \file hip_analyzer_tracepoint_provider.cpp
+ * \brief (Automatic) tracepoint definition translation unit
+ *
+ * \author Sébastien Darche <sebastien.darche@polymtl.ca>
+ */
+
+#ifdef ENABLE_TRACEPOINTS
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEINE
+
+#include "hip_analyzer_tracepoints.h"
+
+#endif

--- a/src/hip_trace_manager.cpp
+++ b/src/hip_trace_manager.cpp
@@ -12,7 +12,6 @@
 #include <iostream>
 #include <sstream>
 
-#define LTTNG_UST_TRACEPOINT_DEFINE
 #include "hip_analyzer_tracepoints.h"
 
 namespace hip {

--- a/src/queue_info.cpp
+++ b/src/queue_info.cpp
@@ -143,6 +143,8 @@ void QueueInfo::computeSizeWaveFromThread() {
 
         commit_wave();
     }
+
+    lttng_ust_tracepoint(hip_instrumentation, queue_compute_end, this);
 }
 
 void QueueInfo::computeSizeWaveFromWave() {

--- a/src/state_recoverer.cpp
+++ b/src/state_recoverer.cpp
@@ -12,6 +12,8 @@
 #include <dlfcn.h>
 #include <new>
 
+#include "hip_analyzer_tracepoints.h"
+
 namespace hip {
 
 StateRecoverer::~StateRecoverer() {
@@ -124,6 +126,7 @@ hipError_t hipMalloc(void** ptr, size_t size) {
 #ifdef HIP_INSTRUMENTATION_VERBOSE
     std::cout << "hipMalloc : " << *ptr << " (" << size << ")\n";
 #endif
+    lttng_ust_tracepoint(hip_instrumentation, hipMalloc, *ptr);
     if (err != hipSuccess) {
         throw std::bad_alloc();
     }
@@ -134,6 +137,7 @@ hipError_t hipFree(void* ptr) {
 #ifdef HIP_INSTRUMENTATION_VERBOSE
     std::cout << "hipFree : " << ptr << '\n';
 #endif
+    lttng_ust_tracepoint(hip_instrumentation, hipFree, ptr);
     return hip::HipMemoryManager::getInstance().hipFree(ptr);
 }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,10 +2,6 @@
 
 project(hip-analyzer-tests LANGUAGES C CXX)
 
-if(ENABLE_TRACEPOINTS)
-    #add_definitions(-DLTTNG_UST_TRACEPOINT_DEFINE)
-endif()
-
 # ----- block_db ----- #
 
 add_executable(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,10 @@
 
 project(hip-analyzer-tests LANGUAGES C CXX)
 
+if(ENABLE_TRACEPOINTS)
+    #add_definitions(-DLTTNG_UST_TRACEPOINT_DEFINE)
+endif()
+
 # ----- block_db ----- #
 
 add_executable(
@@ -64,6 +68,7 @@ add_custom_command(
     COMMAND ${ROCM_PATH}/hip/bin/hipcc -fPIE -c -I${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/test/gpu_enqueue.cpp -std=c++20 -o ${CMAKE_CURRENT_BINARY_DIR}/gpu_enqueue.o
     DEPENDS 
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_instrumentation.hpp
+        ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_instrumentation_cbindings.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_utils.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/gpu_queue.hpp
         ${CMAKE_SOURCE_DIR}/test/gpu_enqueue.cpp
@@ -81,6 +86,7 @@ add_custom_command(
     COMMAND ${ROCM_PATH}/hip/bin/hipcc -fPIE -c -I${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/test/queue_info.cpp -std=c++20 -o ${CMAKE_CURRENT_BINARY_DIR}/queue_info.o
     DEPENDS 
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_instrumentation.hpp
+        ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_instrumentation_cbindings.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_utils.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/gpu_queue.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/queue_info.hpp
@@ -100,6 +106,7 @@ add_custom_command(
     COMMAND ${ROCM_PATH}/hip/bin/hipcc -fPIE -c -I${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/test/gpu_queue_thread.cpp -std=c++20 -o ${CMAKE_CURRENT_BINARY_DIR}/gpu_queue_thread.o
     DEPENDS 
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_instrumentation.hpp
+        ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_instrumentation_cbindings.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_utils.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/gpu_queue.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/queue_info.hpp
@@ -118,6 +125,7 @@ add_custom_command(
     COMMAND ${ROCM_PATH}/hip/bin/hipcc -fPIE -c -I${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/test/gpu_queue_wave.cpp -std=c++20 -o ${CMAKE_CURRENT_BINARY_DIR}/gpu_queue_wave.o
     DEPENDS 
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_instrumentation.hpp
+        ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_instrumentation_cbindings.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_utils.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/gpu_queue.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/queue_info.hpp
@@ -139,6 +147,7 @@ add_custom_command(
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_utils.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/gpu_queue.hpp
         ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/queue_info.hpp
+        ${CMAKE_SOURCE_DIR}/include/hip_instrumentation/hip_instrumentation_cbindings.hpp
         ${CMAKE_SOURCE_DIR}/test/wavestate.cpp
     VERBATIM
 )


### PR DESCRIPTION
Implement LTTng-UST tracepoints to accurately measure timing data, with no overhead when tracepoints are disabled.